### PR TITLE
add access in setup method

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -30,6 +30,7 @@ export default class VueSocketIO {
      */
     install(Vue){
         if (version <= +Vue.version.split('.')[0]) {
+            Vue.provide('socket', this.io)
             Vue.config.globalProperties.$socket = this.io;
             Vue.config.globalProperties.$vueSocketIo = this;
         } else {


### PR DESCRIPTION
This allows people to access ```this.io``` from components inside the ```setup``` method.
```
  setup() {
    const $io = inject("io");
    $io.emit('message', '...')
```