### PR TITLE
Fix socket event not unsubscribe automatically

### DIFF
--- a/src/mixin.js
+++ b/src/mixin.js
@@ -39,7 +39,7 @@ export default {
     /**
      * unsubscribe when component unmounting
      */
-    beforeDestroy(){
+    beforeUnmount(){
 
         if(this.$options.sockets){
 


### PR DESCRIPTION
-`beforeDestroy` lifecycle hook is deprecated in Vue3. Use `beforeUnmount` instead or the socket event won't unsubscribe automatically when component unmounting.