### PR TITLE
Fix declaration file for TypeScript projects

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,63 +1,49 @@
-import SocketIOClient from "socket.io-client";
-import {
-    DefaultComputed,
-    DefaultData,
-    DefaultMethods,
-    DefaultProps,
-    PropsDefinition,
-} from "vue/types/options";
-import { Vue } from "vue/types/vue";
-import { PluginFunction, PluginObject } from "vue";
-import { Store } from "vuex";
+import { Socket } from "socket.io-client";
+import { App } from "vue";
+import type { Store } from "vuex";
 
 interface socketHandler<T> {
-    (this: T, ...args: any[]): void
+	(this: T, ...args: any[]): void
 }
 
 interface Sockets<V> {
-    [key: string]: socketHandler<V>
+	[key: string]: socketHandler<V>
 }
 
-declare module 'vue/types/vue' {
-    interface Vue {
-        $socket: SocketIOClient.Socket,
-        sockets: {
-            subscribe(eventName: string, handler: socketHandler<Vue>): void,
-            unsubscribe(eventName: string): void,
-        }
-    }
-}
+declare module "@vue/runtime-core" {
 
-declare module 'vue/types/options' {
-    interface ComponentOptions<
-        V extends Vue,
-        Data=DefaultData<V>,
-        Methods=DefaultMethods<V>,
-        Computed=DefaultComputed,
-        PropsDef=PropsDefinition<DefaultProps>,
-        Props=DefaultProps> {
-        sockets?: Sockets<V>
-    }
+	export interface ComponentCustomProperties {
+		$socket: Socket,
+		sockets: {
+			subscribe (eventName: string, handler: socketHandler<App>): void,
+			unsubscribe (eventName: string): void,
+		}
+	}
+
+	export interface ComponentCustomOptions  {
+		sockets?: Sockets<App>;
+	}
+
 }
 
 export interface VueSocketOptions {
-    debug?: boolean;
-    connection: string | SocketIOClient.Socket,
-    vuex?: {
-        store?: Store<any>,
-        actionPrefix?: string,
-        mutationPrefix?: string,
-        options?: {
-            useConnectionNamespace?: boolean
-        }
-    },
-        // type declarations for optional options
-    options?:{
-        path?: string;
-    }
+	debug?: boolean;
+	connection: string | Socket,
+	vuex?: {
+		store?: Store<any>,
+		actionPrefix?: string,
+		mutationPrefix?: string,
+		options?: {
+			useConnectionNamespace?: boolean
+		}
+	},
+	// type declarations for optional options
+	options?: {
+		path?: string;
+	}
 }
 
-export default class VueSocketIO<T> implements PluginObject<T> {
-    constructor (options: VueSocketOptions);
-    install: PluginFunction<T>
+export default class VueSocketIO {
+	constructor (options: VueSocketOptions);
+	install: (app: App) => void;
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,6 @@
 import { Socket } from "socket.io-client";
 import { App } from "vue";
+// @ts-ignore: VueX is an optional dependency
 import type { Store } from "vuex";
 
 interface socketHandler<T> {

--- a/package.json
+++ b/package.json
@@ -31,6 +31,9 @@
   "dependencies": {
     "socket.io-client": "^2.1.1"
   },
+  "peerDependencies": {
+	"vue": "3.x"
+  },
   "devDependencies": {
     "@babel/core": "^7.1.2",
     "@babel/plugin-proposal-class-properties": "^7.1.0",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,13 @@
     "socket.io-client": "^2.1.1"
   },
   "peerDependencies": {
-	"vue": "3.x"
+    "vue": "3.x",
+    "vuex": "4.x"
+  },
+  "peerDependenciesMeta": {
+    "vuex": {
+      "optional": true
+    }
   },
   "devDependencies": {
     "@babel/core": "^7.1.2",


### PR DESCRIPTION
This PR converts the current type declaration file (`index.d.ts`) to support Vue 3, and it works fine on my end. I have also made Vue and VueX peer dependencies, so that I can import their types in the aforementioned file.

Unfortunately, the current version of the `socket.io-client` library that this plugin depends on, lacks TypeScript typings, so I would at least urge an upgrade to `3.x`, or `4.x`.